### PR TITLE
Fix Firebase init during build

### DIFF
--- a/client/src/lib/firebaseClient.js
+++ b/client/src/lib/firebaseClient.js
@@ -4,19 +4,26 @@ import { getFirestore } from "firebase/firestore";
 
 // Your Firebase configuration (replace with your actual config)
 const firebaseConfig = {
-    apiKey: process.env.NEXT_PUBLIC_FIREBASE_API_KEY,
-    authDomain: process.env.NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN,
-    projectId: process.env.NEXT_PUBLIC_FIREBASE_PROJECT_ID,
-    storageBucket: process.env.NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET,
-    messagingSenderId: process.env.NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID,
-    appId: process.env.NEXT_PUBLIC_FIREBASE_APP_ID,
-    measurementId: process.env.NEXT_PUBLIC_FIREBASE_MEASUREMENT_ID,
-  };
-
-if (!getApps().length) {
-  initializeApp(firebaseConfig);
+  apiKey: process.env.NEXT_PUBLIC_FIREBASE_API_KEY,
+  authDomain: process.env.NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN,
+  projectId: process.env.NEXT_PUBLIC_FIREBASE_PROJECT_ID,
+  storageBucket: process.env.NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET,
+  messagingSenderId: process.env.NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID,
+  appId: process.env.NEXT_PUBLIC_FIREBASE_APP_ID,
+  measurementId: process.env.NEXT_PUBLIC_FIREBASE_MEASUREMENT_ID,
+};
+// Only initialize Firebase on the client. During the Next.js build there is no
+// `window` object and the Firebase config values might be empty which would
+// cause "auth/invalid-api-key" errors.
+let app;
+if (typeof window !== "undefined") {
+  if (!getApps().length) {
+    app = initializeApp(firebaseConfig);
+  } else {
+    app = getApps()[0];
+  }
 }
 
-export const auth = getAuth();
-export const provider = new GoogleAuthProvider();
-export const db = getFirestore();
+export const auth = app ? getAuth(app) : null;
+export const provider = app ? new GoogleAuthProvider() : null;
+export const db = app ? getFirestore(app) : null;


### PR DESCRIPTION
## Summary
- avoid initializing Firebase when there's no window

## Testing
- `npm run lint` *(fails: ESLint couldn't find config)*

------
https://chatgpt.com/codex/tasks/task_e_686ea4b0e970833185b9f043cef2a948